### PR TITLE
Incorrect RayWiki link

### DIFF
--- a/listings/index.html
+++ b/listings/index.html
@@ -634,7 +634,7 @@
                     Rayman Fandom Wiki
                 </td>
                 <td>
-                    <img src="../img/favicons/en/rayman.png" alt="" /> <a href="https://raymanpc.com/en/" title="Visit RayWiki" target="_blank"> RayWiki </a>
+                    <img src="../img/favicons/en/rayman.png" alt="" /> <a href="https://raymanpc.com/wiki/en/" title="Visit RayWiki" target="_blank"> RayWiki </a>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
missing the /wiki/ before the /en/