### PR TITLE
Removed WikiTrek Annoucement

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -77,9 +77,6 @@
                 Added 1 German listing: Stardew Valley Fandom Wiki to Stardew Valley Wiki
             </li>
             <li>
-                Added 1 Italian listing: Memory Alpha Fandom Wiki to WikiTrek
-            </li>
-            <li>
                 Added 1 Japanese listing: Pokémon Fandom Wiki to ポケモンWiki
             </li>
             <li>


### PR DESCRIPTION
You added an extra announcement about redirecting to WikiTrek. I have removed said extra annoucement, as it was something already done in Version 3.7.1