### PR TITLE
Fixed a typo

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -93,7 +93,7 @@
             <li>
                 Added additional origins to existing English listings:
                 <ul>
-                    <li>ARK Fandom wikis to ARK Wiki</li>
+                    <li>ARK Fandom wiki to ARK Wiki</li>
                     <li>Baldur's Gate 3 Fandom wiki to Baldur's Gate 3 Wiki</li>
                     <li>Dr. Who Fandom wikis to Tardis Wiki</li>
                     <li>Konami Music Fandom wikis to RemyWiki</li>


### PR DESCRIPTION
There's only one addition Ark Fandom redirect for Ark wiki.gg, and this PR fixes the typo referring to it.