### PR TITLE
Announcements for Neoseeker & Swedish Support alongside Medapedia redirect

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -93,7 +93,7 @@
             <li>
                 Added additional origins to existing English listings:
                 <ul>
-                    <li>ARK Fandom wikis to ARK Wiki</li>
+                    <li>ARK Fandom wiki to ARK Wiki</li>
                     <li>Baldur's Gate 3 Fandom wiki to Baldur's Gate 3 Wiki</li>
                     <li>Dr. Who Fandom wikis to Tardis Wiki</li>
                     <li>Konami Music Fandom wikis to RemyWiki</li>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -65,7 +65,7 @@
                     <li>Konami Music Fandom Wikis to RemyWiki</li>
                     <li>Leviathan Myth Fandom Wiki to Leviathan Myth Wiki</li>
                     <li>Limbus Company Fandom Wiki to Limbus Company Wiki on wiki.gg</li>
-                    <li>Medabots Fandom Wiki</li>
+                    <li>Medabots Fandom Wiki to Medapedia</li>
                     <li>Plague Inc. Fandom Wiki to Plague Inc. Wiki on wiki.gg</li>
                     <li>Pou Fandom Wiki to Poupedia</li>
                     <li>Pressure Fandom Wiki to Pressure Wiki</li>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -111,7 +111,6 @@
                     <li>Mario Fandom wikis (Mario & Luigi, Mario Kart Racing, Mario Party, and Paper Mario) to Super Mario Wiki</li>
                 </ul>
             </li>
-            <li>Added support for Swedish wikis with 1 listing: Svenska Wikisimpsons</li>
             <li>Updated Pizza Tower Wiki's URL from pizzatower.miraheze.org to pizzatower.wiki.
             <li>Fixes for Google search filtering, particularly for video results.</li>
             <li>Other general improvements to codebase to reduce code redunancy.</li>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -100,6 +100,7 @@
                     <li>Mario Fandom wikis (Mario & Luigi, Mario Kart Racing, Mario Party, and Paper Mario) to Super Mario Wiki</li>
                 </ul>
             </li>
+            <li>Added support for Swedish wikis with 1 listing: Svenska Wikisimpsons</li>
             <li>Updated Pizza Tower Wiki's URL from pizzatower.miraheze.org to pizzatower.wiki.
             <li>
                 Other general improvements to codebase to reduce redunancy.

--- a/index.html
+++ b/index.html
@@ -196,13 +196,13 @@
             Indie Wiki Buddy is a browser extension that helps you easily find and support independent wikis.
             <br />
             <br />
-            When you visit a wiki on Fandom or Fextralife, this extension will notify or automatically
+            When you visit a wiki on Fandom, Fextralife, or Neoseeker, this extension will notify or automatically
             redirect you to quality independent wikis when they're available.
             Search results in Google, Bing, DuckDuckGo, Yahoo, Brave, Ecosia, Startpage, Qwant, Kagi, and Yandex
             can also be filtered, guiding you to visit an independent counterpart instead.
             <br />
             <br />
-            Indie Wiki Buddy supports <a href="listings">over 400 quality, independent wikis</a> across 17 languages.
+            Indie Wiki Buddy supports <a href="listings">over 400 quality, independent wikis</a> across 18 languages.
             And you're in full control -- you can choose your experience wiki-by-wiki!
             <br />
             <br />


### PR DESCRIPTION
This PR changes the HTML to announce:

- Neoseeker support, which has been available since Februrary
- Swedish wiki support, which was recently added

In addition, I fixed the Medapedia redirect announcement on the changelog