### PR TITLE
Added Swedish section to Listings

### DIFF
--- a/listings/index.html
+++ b/listings/index.html
@@ -4057,6 +4057,23 @@
             </tr>
         </table>
         <br />
+        <h2>[SV] Swedish (Svenska)</h2>
+        <table>
+            <tr>
+                <th>Destination Wiki</th>
+                <th>Redirected From</th>
+            </tr>
+            <tr>
+                <td>
+                    <img src="..img/favicons/sv/wikisimpsons.png" alt="" /> <a href="https://sv.simpsonswiki.com"
+                        title="Visit Svenska Wikisimpsons" target="_blank"> Svenska Wikisimpsons </a>
+                </td>
+                <td>
+                    Simpsons Fandom Wiki
+                </td>
+            </tr>
+        </table>
+        <br />
         <h2>[TH] Thai (ไทย)</h2>
         <table>
             <tr>


### PR DESCRIPTION
Self-explanatory, I added a section for the supported Swedish wikis on the listing page when I noticed it wasn't there.