### PR TITLE
Remove "en-US" from Firefox URLs

### DIFF
--- a/firefox-mobile/index.html
+++ b/firefox-mobile/index.html
@@ -22,7 +22,7 @@
             <p><a href="..">⇦ Back to home</a></p>
             <br />
             <p>
-                As of December 14, 2023, full add-on support is available for Firefox on Android! Simply visit Indie Wiki Buddy's <a href="https://addons.mozilla.org/en-US/firefox/addon/indie-wiki-buddy/">add-on page</a> from the Firefox app to install it.
+                As of December 14, 2023, full add-on support is available for Firefox on Android! Simply visit Indie Wiki Buddy's <a href="https://addons.mozilla.org/firefox/addon/indie-wiki-buddy/">add-on page</a> from the Firefox app to install it.
             </p>
             <p>
                 See Mozilla's

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
                 target="_blank">
                 <img src="img/browser-chrome.png" alt="Install on Chrome" title="Install on Chrome" width="35" />
             </a>
-            <a class="button-link" href="https://addons.mozilla.org/en-US/firefox/addon/indie-wiki-buddy/"
+            <a class="button-link" href="https://addons.mozilla.org/firefox/addon/indie-wiki-buddy/"
                 target="_blank">
                 <img src="img/browser-firefox.png" alt="Install on Firefox + Firefox for Android"
                     title="Install on Firefox + Firefox for Android" width="35" />
@@ -64,7 +64,7 @@
             </button>
         </a>
         <br />
-        <a class="button-link" href="https://addons.mozilla.org/en-US/firefox/addon/indie-wiki-buddy/" target="_blank">
+        <a class="button-link" href="https://addons.mozilla.org/firefox/addon/indie-wiki-buddy/" target="_blank">
             <button class="button">
                 <div class="flex">
                     <div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -33,7 +33,7 @@
             should visit these websites at their own risk.
             <br /><br />
             Indie Wiki Buddy's settings and stats are stored in your browser's storage, both locally and in 
-            <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync">
+            <a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync">
             sync storage</a> (if supported).
             <br /><br />
             Indie Wiki Buddy can see which Fandom, Fextralife, and Neoseeker wikis you visit for the purpose of
@@ -54,7 +54,7 @@
             <br /><br />
             Your browser and the online store you acquire the extension through (e.g.
             <a href="https://chrome.google.com/webstore/category/extensions">Chrome Web Store</a> or
-            <a href="https://addons.mozilla.org/en-US/firefox/extensions/">Firefox Add-ons</a>) may perform its own
+            <a href="https://addons.mozilla.org/firefox/extensions/">Firefox Add-ons</a>) may perform its own
             data collection.
         </p>
     </div>


### PR DESCRIPTION
This will redirect users to the most appropriate language.