### PR TITLE
Fixed a changelog typo and added Firefox 2.13.0 release date

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -41,7 +41,7 @@
         <h2>3.13.1</h2>
         <span>
             <img class="browser-icon" src="../img/browser-chrome.png" alt="Chrome release date"> February 4, 2025
-            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> Pending release
+            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> February 21, 2025
         </span>
         <ul>
             <li>Added 3 English listings:</li>

--- a/changelog/index.html
+++ b/changelog/index.html
@@ -54,7 +54,7 @@
         <h2>3.13.0</h2>
         <span>
             <img class="browser-icon" src="../img/browser-chrome.png" alt="Chrome release date"> February 2, 2025
-            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> Pending release
+            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> February 11, 2025
         </span>
         <ul>
             <li>
@@ -262,7 +262,7 @@
                 Added 1 French listing: The Binding Of Isaac: Rebirth Fandom Wiki to The Binding Of Isaac: Rebirth Fandom Wiki on wiki.gg
             </li>
             <li>
-                Added 2 German listing:
+                Added 2 German listings:
                 <ul>
                     <li>South Park Fandom Wiki to South Park Wiki on wiki.gg</li>
                     <li>Zeldapedia Fandom Wiki to Zeldapendium</li>


### PR DESCRIPTION
Self-explanatory, I added an 's' where it was sorely needed and added the release date for 2.13.0 on Firefox.