### PR TITLE
Updated Changelog for 3.13.6 Firefox

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -41,12 +41,12 @@
         <h2>3.13.6</h2>
         <span>
             <img class="browser-icon" src="../img/browser-chrome.png" alt="Chrome release date"> June 24, 2025
-            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> Pending release
+            <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date"> June 30, 2025
         </span>
         <ul>
             <li>Added 1 French listing: ZeldaWiki on Fandom to Zelda Wiki</li>
             <li>
-                Added 9 English listings:
+                Added 16 English listings:
                 <ul>
                     <li>Balatro Fandom Wiki to Balatro Wiki</li>
                     <li>Bloons Fandom Wiki to Blooncyclopedia</li>


### PR DESCRIPTION
Added the 3.13.6 Firefox release date and corrected the erroneous number of added English listings.