### PR TITLE
Updated supported wikis count from +650 to +700

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     </div>
     <div class="container">
         <div class="align-center">
-            <h2>A few of our 650+ supported wikis <small>(<a href="listings">see all listings</a>)</small></h2>
+            <h2>A few of our 700+ supported wikis <small>(<a href="listings">see all listings</a>)</small></h2>
         </div>
         <div class="scroll">
             <div class="m-scroll1">
@@ -202,7 +202,7 @@
             can also be filtered, guiding you to visit an independent counterpart instead.
             <br />
             <br />
-            Indie Wiki Buddy supports <a href="listings">over 650 quality, independent wikis</a> across 20 languages.
+            Indie Wiki Buddy supports <a href="listings">over 700 quality, independent wikis</a> across 20 languages.
             And you're in full control -- you can choose your experience wiki-by-wiki!
             <br />
             <br />


### PR DESCRIPTION
IWB currently has 748 wikis as of v3.14.2