### PR TITLE
Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Kevin Payravi
+Copyright (c) 2026 Kevin Payravi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I know it's not really significant, but it's hasn't been changed in almost five months. We are already in 2026.