### PR TITLE
Update wiki count to 800 and Chrome release date

### DIFF
--- a/changelog/index.html
+++ b/changelog/index.html
@@ -40,7 +40,7 @@
         </div>
         <h2>3.14.6</h2>
         <span>
-            <img class="browser-icon" src="../img/browser-chrome.png" alt="Chrome release date" /> Pending release
+            <img class="browser-icon" src="../img/browser-chrome.png" alt="Chrome release date" /> May 21, 2026
             <img class="browser-icon" src="../img/browser-firefox.png" alt="Firefox release date" /> Pending release
         </span>
         <ul>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
     </div>
     <div class="container">
         <div class="align-center">
-            <h2>A few of our 700+ supported wikis <small>(<a href="listings">see all listings</a>)</small></h2>
+            <h2>A few of our 800+ supported wikis <small>(<a href="listings">see all listings</a>)</small></h2>
         </div>
         <div class="scroll">
             <div class="m-scroll1">
@@ -202,7 +202,7 @@
             can also be filtered, guiding you to visit an independent counterpart instead.
             <br />
             <br />
-            Indie Wiki Buddy supports <a href="listings">over 700 quality, independent wikis</a> across 20 languages.
+            Indie Wiki Buddy supports <a href="listings">over 800 quality, independent wikis</a> across 22 languages.
             And you're in full control -- you can choose your experience wiki-by-wiki!
             <br />
             <br />


### PR DESCRIPTION
IWB has 824 wikis as of 3.14.6. Also added Chrome release date
Also, I had no time to add the new wikis to the listing, so I'm sorry about that. 🥲